### PR TITLE
Enhance UI with dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,13 @@
     }
   </style>
 </head>
-<body class="bg-gray-100 min-h-screen">
+<body class="bg-gray-100 dark:bg-gray-900 min-h-screen text-gray-900 dark:text-gray-100">
   <div class="container mx-auto p-4">
     <div class="flex flex-col sm:flex-row justify-between items-center mb-4 gap-4">
       <h1 class="text-3xl font-bold">GitHub 多用户仓库展示</h1>
       <!-- 最后更新时间显示 -->
-      <div id="last-update" class="text-gray-600 text-sm whitespace-nowrap"></div>
+      <div id="last-update" class="text-gray-600 dark:text-gray-300 text-sm whitespace-nowrap"></div>
+      <button id="theme-toggle" class="ml-2 px-2 py-1 border rounded text-sm bg-gray-200 dark:bg-gray-700">🌙</button>
     </div>
 
     <div class="mb-4 flex flex-wrap gap-4 items-center">
@@ -51,6 +52,23 @@
     let allData = [];
     let currentRepos = [];
     let currentPage = 1;
+
+    // 主题切换
+    const themeToggle = document.getElementById("theme-toggle");
+    const savedTheme = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+      document.documentElement.classList.add("dark");
+    }
+    themeToggle.textContent = document.documentElement.classList.contains("dark")
+      ? "☀️"
+      : "🌙";
+    themeToggle.addEventListener("click", () => {
+      document.documentElement.classList.toggle("dark");
+      const isDark = document.documentElement.classList.contains("dark");
+      themeToggle.textContent = isDark ? "☀️" : "🌙";
+      localStorage.setItem("theme", isDark ? "dark" : "light");
+    });
 
     function formatDateTime(date) {
       const y = date.getFullYear();
@@ -143,16 +161,18 @@
           const day24Ms = 24 * 60 * 60 * 1000;
           const isRecent = diffMs <= day24Ms;
           const formattedTime = formatDateTime(pushedDate);
-          const timeClass = isRecent ? "text-gradient font-semibold" : "text-gray-400";
+          const timeClass = isRecent
+            ? "text-gradient font-semibold"
+            : "text-gray-400 dark:text-gray-500";
 
           return `
-          <div class="bg-white rounded-xl shadow-md p-4 hover:shadow-lg transition-all border-2 border-transparent hover:border-blue-400">
+          <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-4 hover:shadow-lg transition-all border border-gray-200 dark:border-gray-700 hover:border-blue-400">
             <div class="flex justify-between items-center">
               <a href="${repo.url}" target="_blank" class="text-lg font-bold text-blue-600 hover:underline">${repo.name}</a>
-              <span class="bg-gray-200 text-xs rounded px-2">${repo.language || "未知"}</span>
+              <span class="bg-gray-200 dark:bg-gray-700 text-xs rounded px-2">${repo.language || "未知"}</span>
             </div>
-            <div class="text-gray-600 mb-2">${repo.description || "无简介"}</div>
-            <div class="flex justify-between items-center text-sm text-gray-500">
+            <div class="text-gray-600 dark:text-gray-300 mb-2">${repo.description || "无简介"}</div>
+            <div class="flex justify-between items-center text-sm text-gray-500 dark:text-gray-400">
               <div>
                 <span>⭐${repo.stars}</span>
                 <span class="ml-2">🍴${repo.forks}</span>
@@ -180,8 +200,10 @@
       for (let i = 1; i <= totalPages; i++) {
         const btn = document.createElement("button");
         btn.textContent = i;
-        btn.className = `px-3 py-1 rounded ${
-          i === currentPage ? "bg-blue-500 text-white" : "bg-gray-200"
+        btn.className = `px-3 py-1 rounded border transition-colors ${
+          i === currentPage
+            ? "bg-blue-500 border-blue-500 text-white"
+            : "bg-gray-200 dark:bg-gray-700 border-gray-300 dark:border-gray-600 hover:bg-blue-500 hover:text-white"
         }`;
         btn.onclick = () => renderPage(i);
         container.appendChild(btn);


### PR DESCRIPTION
## Summary
- add dark mode support with theme toggle
- improve repo cards and pagination styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684058448f5083228ae1e6cea6f927e1